### PR TITLE
Switch to astropy build and add pip to conda dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ group: travis_latest
 cache: pip
 sudo: false
 python:
-- '3.8'
+- '3.6'
 
 
 env:
@@ -11,7 +11,7 @@ env:
   - secure: QM4CHEqPdDEUhrQYvkOz4DqxNjUNHLVRkxCSy4raFgTEAUyiPF+nF2z8Q1s8lfTxBwmjgEgLpxBMCRI2wbkLJirHwAdpvkH3aNzla4o2mgNdSyl1zSQrflM8/eJ3uEQjx69dcfPQWmED1hQQceh+Gd2c9hhfDdPv12viqHhFp5/TEeXRILHczbE0bC8efxSI87xi5a6rCm6c+Uohmc7Xy5+PraVsuxrRWU7NESqTYuIr14gT8p38SvwCafALpYw7i0Ch1ue/ffrsPKlnnCGd/HTE7YMcw61dUh9Y8QYTSJaBBdLS8ytwTyaN4/4LEEqaHihwKko8j03hUi+TM+d/lmKYh3y3U7U3BaofW/aGJu5Xuo6eKtgwA2WX/yTLdVQbnMgDOtJiKQ7G4wAKO4UUffRbdUc3ioOKBPEPjhyQ/Qo3NEozGt0SUNzEdeFIMaQbBQzxzGy+NNByPnOlvPK4u6hvAluPPVqGaVV7gAh5NRzPrAoChK2TYASZVCd9SQ8HfnFdv5aWn/rt6wnf2wVRcCxtQXSKdazaLFv1noSO44PWprRNskI2xYEjrFRMk/Drk7uNBCcJH0apBbDyAzaQ+izjyWllGztrebjQcJSagfhES/Rt6WBjuwAVzElHwRgIWxrGn1t0MzT3q7IfAQlXedRhGyv4e+dxehjZdv7m4W8=
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
-  - PYTHON_VERSION=3.8
+  - PYTHON_VERSION=3.6
   - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
   - CONDA_CHANNELS='defaults conda-forge plotly'
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
   - PYTHON_VERSION=3.6
-  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
-  - CONDA_CHANNELS='defaults conda-forge plotly'
-  - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
+  - CONDA_ENVIRONMENT=environment.yml
+    #  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+    # - CONDA_CHANNELS='defaults conda-forge plotly'
+    #- PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
   - CYTHON_TRACE_NOGIL=1
   - MPLBACKEND=agg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 cache: pip
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+dist: xenial
 language: python
 cache: pip
-sudo: false
 python:
 - '3.6'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ env:
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
   - PYTHON_VERSION=3.6
-  - CONDA_ENVIRONMENT=environment.yml
-    #  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
-    # - CONDA_CHANNELS='defaults conda-forge plotly'
-    #- PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
+  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+  - CONDA_CHANNELS='defaults conda-forge plotly'
+  - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
   - CYTHON_TRACE_NOGIL=1
   - MPLBACKEND=agg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,25 @@ env:
   - secure: QM4CHEqPdDEUhrQYvkOz4DqxNjUNHLVRkxCSy4raFgTEAUyiPF+nF2z8Q1s8lfTxBwmjgEgLpxBMCRI2wbkLJirHwAdpvkH3aNzla4o2mgNdSyl1zSQrflM8/eJ3uEQjx69dcfPQWmED1hQQceh+Gd2c9hhfDdPv12viqHhFp5/TEeXRILHczbE0bC8efxSI87xi5a6rCm6c+Uohmc7Xy5+PraVsuxrRWU7NESqTYuIr14gT8p38SvwCafALpYw7i0Ch1ue/ffrsPKlnnCGd/HTE7YMcw61dUh9Y8QYTSJaBBdLS8ytwTyaN4/4LEEqaHihwKko8j03hUi+TM+d/lmKYh3y3U7U3BaofW/aGJu5Xuo6eKtgwA2WX/yTLdVQbnMgDOtJiKQ7G4wAKO4UUffRbdUc3ioOKBPEPjhyQ/Qo3NEozGt0SUNzEdeFIMaQbBQzxzGy+NNByPnOlvPK4u6hvAluPPVqGaVV7gAh5NRzPrAoChK2TYASZVCd9SQ8HfnFdv5aWn/rt6wnf2wVRcCxtQXSKdazaLFv1noSO44PWprRNskI2xYEjrFRMk/Drk7uNBCcJH0apBbDyAzaQ+izjyWllGztrebjQcJSagfhES/Rt6WBjuwAVzElHwRgIWxrGn1t0MzT3q7IfAQlXedRhGyv4e+dxehjZdv7m4W8=
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
+  - PYTHON_VERSION=3.6
+  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+  - CONDA_CHANNELS='defaults conda-forge plotly'
+  - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
+  - CYTHON_TRACE_NOGIL=1
+  - MPLBACKEND=agg
 before_install:
-- sudo apt-get update
+#- sudo apt-get update
 - sudo apt-get install -y pandoc
-- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-- MINICONDA_PATH=$HOME/miniconda
-- bash miniconda.sh -b -p $MINICONDA_PATH
-- export PATH=$MINICONDA_PATH/bin:$PATH
-- conda update --yes conda
+  #- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  #- MINICONDA_PATH=$HOME/miniconda
+  #- bash miniconda.sh -b -p $MINICONDA_PATH
+  #- export PATH=$MINICONDA_PATH/bin:$PATH
+  #- conda update --yes condaa
 install:
-- conda env create python=3.6 -f environment.yml --quiet
-- source activate mda-user-guide
+- git clone git://github.com/astropy/ci-helpers.git
+- source ci-helpers/travis/setup_conda.sh
+  #- conda env create python=3.6 -f environment.yml --quiet
+  #- source activate mda-user-guide
 - jupyter-nbextension enable nglview --py --sys-prefix
 script:
 - make -C ${SPHINX_DIR} html && touch ${HTML_DIR}/.nojekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ group: travis_latest
 cache: pip
 sudo: false
 python:
-- '3.6'
+- '3.8'
 
 
 env:
@@ -11,7 +11,7 @@ env:
   - secure: QM4CHEqPdDEUhrQYvkOz4DqxNjUNHLVRkxCSy4raFgTEAUyiPF+nF2z8Q1s8lfTxBwmjgEgLpxBMCRI2wbkLJirHwAdpvkH3aNzla4o2mgNdSyl1zSQrflM8/eJ3uEQjx69dcfPQWmED1hQQceh+Gd2c9hhfDdPv12viqHhFp5/TEeXRILHczbE0bC8efxSI87xi5a6rCm6c+Uohmc7Xy5+PraVsuxrRWU7NESqTYuIr14gT8p38SvwCafALpYw7i0Ch1ue/ffrsPKlnnCGd/HTE7YMcw61dUh9Y8QYTSJaBBdLS8ytwTyaN4/4LEEqaHihwKko8j03hUi+TM+d/lmKYh3y3U7U3BaofW/aGJu5Xuo6eKtgwA2WX/yTLdVQbnMgDOtJiKQ7G4wAKO4UUffRbdUc3ioOKBPEPjhyQ/Qo3NEozGt0SUNzEdeFIMaQbBQzxzGy+NNByPnOlvPK4u6hvAluPPVqGaVV7gAh5NRzPrAoChK2TYASZVCd9SQ8HfnFdv5aWn/rt6wnf2wVRcCxtQXSKdazaLFv1noSO44PWprRNskI2xYEjrFRMk/Drk7uNBCcJH0apBbDyAzaQ+izjyWllGztrebjQcJSagfhES/Rt6WBjuwAVzElHwRgIWxrGn1t0MzT3q7IfAQlXedRhGyv4e+dxehjZdv7m4W8=
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
-  - PYTHON_VERSION=3.6
+  - PYTHON_VERSION=3.8
   - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
   - CONDA_CHANNELS='defaults conda-forge plotly'
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-dist: bionic
 language: python
+group: travis_latest
 cache: pip
+sudo: false
 python:
 - '3.6'
+
+
 env:
   global:
   - secure: QM4CHEqPdDEUhrQYvkOz4DqxNjUNHLVRkxCSy4raFgTEAUyiPF+nF2z8Q1s8lfTxBwmjgEgLpxBMCRI2wbkLJirHwAdpvkH3aNzla4o2mgNdSyl1zSQrflM8/eJ3uEQjx69dcfPQWmED1hQQceh+Gd2c9hhfDdPv12viqHhFp5/TEeXRILHczbE0bC8efxSI87xi5a6rCm6c+Uohmc7Xy5+PraVsuxrRWU7NESqTYuIr14gT8p38SvwCafALpYw7i0Ch1ue/ffrsPKlnnCGd/HTE7YMcw61dUh9Y8QYTSJaBBdLS8ytwTyaN4/4LEEqaHihwKko8j03hUi+TM+d/lmKYh3y3U7U3BaofW/aGJu5Xuo6eKtgwA2WX/yTLdVQbnMgDOtJiKQ7G4wAKO4UUffRbdUc3ioOKBPEPjhyQ/Qo3NEozGt0SUNzEdeFIMaQbBQzxzGy+NNByPnOlvPK4u6hvAluPPVqGaVV7gAh5NRzPrAoChK2TYASZVCd9SQ8HfnFdv5aWn/rt6wnf2wVRcCxtQXSKdazaLFv1noSO44PWprRNskI2xYEjrFRMk/Drk7uNBCcJH0apBbDyAzaQ+izjyWllGztrebjQcJSagfhES/Rt6WBjuwAVzElHwRgIWxrGn1t0MzT3q7IfAQlXedRhGyv4e+dxehjZdv7m4W8=
@@ -14,22 +17,23 @@ env:
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex"
   - CYTHON_TRACE_NOGIL=1
   - MPLBACKEND=agg
+
+
 before_install:
-#- sudo apt-get update
-- sudo apt-get install -y pandoc
-  #- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  #- MINICONDA_PATH=$HOME/miniconda
-  #- bash miniconda.sh -b -p $MINICONDA_PATH
-  #- export PATH=$MINICONDA_PATH/bin:$PATH
-  #- conda update --yes condaa
+  - sudo apt-get update
+  - sudo apt-get install -y pandoc
+
+
 install:
-- git clone git://github.com/astropy/ci-helpers.git
-- source ci-helpers/travis/setup_conda.sh
-  #- conda env create python=3.6 -f environment.yml --quiet
-  #- source activate mda-user-guide
-- jupyter-nbextension enable nglview --py --sys-prefix
+  - git clone git://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda.sh
+  - jupyter-nbextension enable nglview --py --sys-prefix
+
+
 script:
-- make -C ${SPHINX_DIR} html && touch ${HTML_DIR}/.nojekyll
+  - make -C ${SPHINX_DIR} html && touch ${HTML_DIR}/.nojekyll
+
+
 deploy:
   provider: pages
   skip_cleanup: true

--- a/doc/source/AUTHORS
+++ b/doc/source/AUTHORS
@@ -25,4 +25,5 @@ Chronological list of authors
   - Oliver Beckstein
 2020
   - Rocco Meli
+  - Irfan Alibay
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - mdanalysis=0.20.1
   - MDAnalysisTests
   - plotly
+  - pip
   - pip:
       - sphinx_rtd_theme
       - sphinx-sitemap

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - nglview
   - sphinx
   - ipywidgets
-  - mdanalysis=0.20.1
+  - mdanalysis
   - MDAnalysisTests
   - plotly
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - mdanalysis=0.20.1
   - MDAnalysisTests
   - plotly
-  - pip
   - pip:
       - sphinx_rtd_theme
       - sphinx-sitemap


### PR DESCRIPTION
Fixes #85, #82 

 - Switches over the travis.yml file from doing a simple miniconda install to using astropy's ci-helper.
 - Also a very very minor change, but might as well make conda happy :)