### PR TITLE
pin numpy to 1.18.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
   - conda env create python=3.6 -f environment.yml
-  - conda activate mda-user-guide
+  - source activate mda-user-guide
   - jupyter-nbextension enable nglview --py --sys-prefix
   - conda list
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
   - PYTHON_VERSION=3.6
-  - CONDA_DEPENDENCIES="numpy==1.18.5 jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
   - CONDA_CHANNELS='defaults conda-forge plotly'
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0"
   - CYTHON_TRACE_NOGIL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
   - PYTHON_VERSION=3.6
-  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+  - CONDA_DEPENDENCIES="numpy==1.18.5 jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
   - CONDA_CHANNELS='defaults conda-forge plotly'
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0"
   - CYTHON_TRACE_NOGIL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
   - secure: QM4CHEqPdDEUhrQYvkOz4DqxNjUNHLVRkxCSy4raFgTEAUyiPF+nF2z8Q1s8lfTxBwmjgEgLpxBMCRI2wbkLJirHwAdpvkH3aNzla4o2mgNdSyl1zSQrflM8/eJ3uEQjx69dcfPQWmED1hQQceh+Gd2c9hhfDdPv12viqHhFp5/TEeXRILHczbE0bC8efxSI87xi5a6rCm6c+Uohmc7Xy5+PraVsuxrRWU7NESqTYuIr14gT8p38SvwCafALpYw7i0Ch1ue/ffrsPKlnnCGd/HTE7YMcw61dUh9Y8QYTSJaBBdLS8ytwTyaN4/4LEEqaHihwKko8j03hUi+TM+d/lmKYh3y3U7U3BaofW/aGJu5Xuo6eKtgwA2WX/yTLdVQbnMgDOtJiKQ7G4wAKO4UUffRbdUc3ioOKBPEPjhyQ/Qo3NEozGt0SUNzEdeFIMaQbBQzxzGy+NNByPnOlvPK4u6hvAluPPVqGaVV7gAh5NRzPrAoChK2TYASZVCd9SQ8HfnFdv5aWn/rt6wnf2wVRcCxtQXSKdazaLFv1noSO44PWprRNskI2xYEjrFRMk/Drk7uNBCcJH0apBbDyAzaQ+izjyWllGztrebjQcJSagfhES/Rt6WBjuwAVzElHwRgIWxrGn1t0MzT3q7IfAQlXedRhGyv4e+dxehjZdv7m4W8=
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
-  - PYTHON_VERSION=3.6
-  - CONDA_DEPENDENCIES="numpy==1.19 jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
-  - CONDA_CHANNELS='defaults conda-forge plotly'
-  - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0"
   - CYTHON_TRACE_NOGIL=1
   - MPLBACKEND=agg
 
@@ -28,11 +24,16 @@ env:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y pandoc
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - MINICONDA_PATH=$HOME/miniconda
+  - bash miniconda.sh -b -p $MINICONDA_PATH
+  - export PATH=$MINICONDA_PATH/bin:$PATH
+  - conda update --yes conda
 
 
 install:
-  - git clone git://github.com/astropy/ci-helpers.git
-  - source ci-helpers/travis/setup_conda.sh
+  - conda env create python=3.6 -f environment.yml
+  - conda activate mda-user-guide
   - jupyter-nbextension enable nglview --py --sys-prefix
   - conda list
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - SPHINX_DIR=doc/
   - HTML_DIR=doc/build/html
   - PYTHON_VERSION=3.6
-  - CONDA_DEPENDENCIES="jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
+  - CONDA_DEPENDENCIES="numpy==1.19 jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly"
   - CONDA_CHANNELS='defaults conda-forge plotly'
   - PIP_DEPENDENCIES="sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0"
   - CYTHON_TRACE_NOGIL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 
 
 install:
-  - conda env create python=3.6 -f environment.yml
+  - conda env create python=3.6 -f environment.yml --quiet
   - conda activate mda-user-guide
   - jupyter-nbextension enable nglview --py --sys-prefix
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,18 @@ before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - MINICONDA_PATH=$HOME/miniconda
   - bash miniconda.sh -b -p $MINICONDA_PATH
-  - export PATH=$MINICONDA_PATH/bin:$PATH
+  - $HOME/miniconda/bin/conda init bash
+  - source ~/.bash_profile
+  - conda activate base
   - conda update --yes conda
 
 
 install:
-  - conda env create python=3.6 -f environment.yml
-  - source activate mda-user-guide
+  - conda create --yes -n test python=3.6
+  - conda activate test
+  - conda install --yes numpy<1.19.0
+  - conda install --yes pip jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly ipython -c conda-forge -c plotly
+  - pip install sphinx_rtd_theme sphinx-sitemap nbsphinx tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0
   - jupyter-nbextension enable nglview --py --sys-prefix
   - conda list
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
   - conda create --yes -n test python=3.6
   - conda activate test
-  - conda install --yes numpy<1.19.0
+  - conda install --yes numpy==1.18.5
   - conda install --yes pip jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly ipython -c conda-forge -c plotly
   - pip install sphinx_rtd_theme sphinx-sitemap nbsphinx tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0
   - jupyter-nbextension enable nglview --py --sys-prefix

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,8 @@ before_install:
 
 
 install:
-  - conda create --yes -n test python=3.6
-  - conda activate test
-  - conda install --yes numpy==1.18.5
-  - conda install --yes pip jupyter_contrib_nbextensions nglview sphinx ipywidgets MDAnalysis MDAnalysisTests plotly ipython -c conda-forge -c plotly
-  - pip install sphinx_rtd_theme sphinx-sitemap nbsphinx tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0
+  - conda env create python=3.6 -f environment.yml
+  - conda activate mda-user-guide
   - jupyter-nbextension enable nglview --py --sys-prefix
   - conda list
   

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - MDAnalysisTests
   - nbsphinx
   - nglview
-  - numpy<1.19.0
+  - defaults::numpy<1.19.0
   - pip
   - plotly
   - pybtex

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - MDAnalysisTests
   - nbsphinx
   - nglview
-  - numpy>=1.18.5
+  - numpy<1.19.0
   - pip
   - plotly
   - pybtex


### PR DESCRIPTION
So I was testing what could be causing this, and given the timelines and everything it seems like it _could_ be down to numpy 1.19.

At least in my own test case (I created a clean repo with a call to aligntraj with a u.copy()), it seems that this is the case, let's see how it fares here.