### PR TITLE
Add examples of selecting groups from other groups

### DIFF
--- a/doc/source/AUTHORS
+++ b/doc/source/AUTHORS
@@ -26,4 +26,5 @@ Chronological list of authors
 2020
   - Rocco Meli
   - Irfan Alibay
+  - Mieczyslaw Torchala
 

--- a/doc/source/groups_of_atoms.rst
+++ b/doc/source/groups_of_atoms.rst
@@ -64,6 +64,66 @@ Similarly, an :class:`~MDAnalysis.core.groups.Atom` has direct knowledge of the 
 
 For information on adding custom Residues or Segments, have a look at :ref:`adding-residue`.
 
+Access to various data views via :class:`~MDAnalysis.core.groups.AtomGroup` object can be pretty powerful, but also
+needs to be used with caution to avoid accessing data outside the intended selection, as mentioned above. Therefore,
+we present two use cases showing commonly used applications.
+
+---------------------------------------
+Use case: Sequence of residues by chain
+---------------------------------------
+Let's assume that we have a PDB file, which contains both ATOM and HETATM record types, for protein and small molecule,
+respectively. In order to select only ATOM record types and get a list of residues by chain, one needs to call:
+
+.. code-block:: python
+
+    u = mda.Universe(pdb, format="PDB")
+    for seg in u.segments:
+        p_seg = seg.atoms.select_atoms("record_type ATOM")
+        r_list = p_seg.residues.resnames
+        print(r_list)
+
+This can be used later on to check whether the residue names belong, for example, to the list of standard residues.
+However, it would be **incorrect** to use:
+
+.. code-block:: python
+
+    selected_atoms = u.select_atoms("record_type ATOM")  # CORRECT SYNTAX, BUT INCORRECT RETURN VALUE!
+    residues_wrong = selected_atoms.segments.resnames  # CORRECT SYNTAX, BUT INCORRECT RETURN VALUE!
+    print(residues_wrong)  # CORRECT SYNTAX, BUT INCORRECT RETURN VALUE!
+
+because, although it nicely returns list of residues in every chain (list of lists, so no need to additionally
+loop through segments), it would return all residues, both for ATOM and HETATM record types, because this construct
+means "give me all residue names from segments in which there is at least one of the selected atoms".
+
+----------------------------------------
+Use case: Atoms list grouped by residues
+----------------------------------------
+In another use case, let's assume that we would like to check if all the heavy protein backbone and sidechain atoms
+are present in every residue. We can easily prepare the expected atom names list in every standard residue, but
+we need to obtain the list of atoms in every residue to compare with (using, for example, a symmetrical difference).
+In order to do that, we want to avoid HETATMs, OXT and hydrogen (H*) atoms, and we need to loop over segments (chains)
+and residues:
+
+.. code-block:: python
+
+    u = mda.Universe(pdb, format="PDB")
+    for seg in u.segments:
+        p_seg = seg.atoms.select_atoms("record_type ATOM and not (name H* or name OXT)")
+        for p_res in p_seg.residues:
+            atoms_in_residue = p_seg.select_atoms(f"resid {p_res.resid} and resname {p_res.resname}").names.tolist()
+            print(atoms_in_residue)
+
+However, it would be **incorrect** to use in the body of the first loop:
+
+.. code-block:: python
+
+    atoms_in_residue_wrong = p_seg.residues.names  # CORRECT SYNTAX, BUT INCORRECT RETURN VALUE!
+    print(atoms_in_residue_wrong)  # CORRECT SYNTAX, BUT INCORRECT RETURN VALUE!
+
+because, although it nicely returns list of atoms in every residue, it would return all atoms (including hydrogen ones),
+because this construct means "give me all atom names from residues in which there is at least one of the selected
+atoms".
+
 ---------------------------
 Fragments
 ---------------------------


### PR DESCRIPTION
Although, both syntactically correct, only one solution to every use case returns expected results. This should help people to avoid using AtomGroups incorrectly, especially when seeing all the possibilities via a interactive debugging session on objects.

I have rebuilt the documentation and confirmed that the webpage after updates is as expected.