### PR TITLE
Change intersphinx link to latest objects.inv

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -182,9 +182,10 @@ html_sidebars = {
 
 # Configuration for intersphinx: refer to the Python standard library
 # and other packages used by MDAnalysis
+mda_version = mda.__version__
 intersphinx_mapping = {'https://docs.python.org/': None,
                        'https://docs.scipy.org/doc/numpy/': None,
-                       'https://www.mdanalysis.org/docs/': None,
+                       f'https://docs.mdanalysis.org/{mda_version}/': None,
                        'https://docs.pytest.org/en/latest/': None,
                        'https://chemfiles.org/chemfiles.py/latest/': None,
                        'http://parmed.github.io/ParmEd/html/': None,


### PR DESCRIPTION
Fixes #103 

This looks at the MDAnalysis version to work out which `objects.inv` to use. I think https://github.com/MDAnalysis/mdanalysis/pull/2955 might suffice to redirect `latest/objects.inv` to `my-version/objects.inv` but this likely suits the purposes of the user guide more.