### PR TITLE
Install develop version of MDAnalysis in develop version of user guide

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -34,7 +34,7 @@ jobs:
         python-version: 3.7
         auto-update-conda: true
         channel-priority: flexible
-        channels: plotly, conda-forge
+        channels: plotly, conda-forge, biobuilds
         add-pip-as-python-dependency: true
         architecture: x64
         environment-file: environment.yml

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,6 +45,7 @@ jobs:
         jupyter-nbextension enable nglview --py --sys-prefix
 
         # develop
+        conda install ${{ env.CONDA_MDA_DEPS }}
         git clone https://github.com/MDAnalysis/mdanalysis.git
         cd mdanalysis/package
         python setup.py install

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,7 +45,7 @@ jobs:
         jupyter-nbextension enable nglview --py --sys-prefix
 
         # develop
-        git clone git@github.com:MDAnalysis/mdanalysis.git
+        git clone https://github.com/MDAnalysis/mdanalysis.git
         cd mdanalysis/package
         python setup.py install
         cd ../testsuite

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -44,6 +44,13 @@ jobs:
       run: |
         jupyter-nbextension enable nglview --py --sys-prefix
 
+        # develop
+        git clone git@github.com:MDAnalysis/mdanalysis.git
+        cd mdanalysis/package
+        python setup.py install
+        cd ../testsuite
+        python setup.py install
+
     - name: build_docs
       run: |
         make -C ${SPHINX_DIR} html

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -44,15 +44,6 @@ jobs:
       run: |
         jupyter-nbextension enable nglview --py --sys-prefix
 
-        conda install ${{ env.CONDA_MDA_DEPS }}
-
-    - name: install_mda
-      run: |
-        # develop
-        git clone https://github.com/MDAnalysis/mdanalysis.git
-        cd mdanalysis
-        (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
-
     - name: build_docs
       run: |
         make -C ${SPHINX_DIR} html

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -34,7 +34,7 @@ jobs:
         python-version: 3.7
         auto-update-conda: true
         channel-priority: flexible
-        channels: plotly, conda-forge, biobuilds
+        channels: biobuilds, plotly, conda-forge
         add-pip-as-python-dependency: true
         architecture: x64
         environment-file: environment.yml
@@ -44,13 +44,14 @@ jobs:
       run: |
         jupyter-nbextension enable nglview --py --sys-prefix
 
-        # develop
         conda install ${{ env.CONDA_MDA_DEPS }}
+
+    - name: install_mda
+      run: |
+        # develop
         git clone https://github.com/MDAnalysis/mdanalysis.git
-        cd mdanalysis/package
-        python setup.py install
-        cd ../testsuite
-        python setup.py install
+        cd mdanalysis
+        (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
 
     - name: build_docs
       run: |


### PR DESCRIPTION
We need to install the development version of MDAnalysis in order to run the ``ipython`` code that relies on the new changes.