### PR TITLE
Only deploy docs on merge

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -51,6 +51,7 @@ jobs:
         make -C ${SPHINX_DIR} html
 
     - name: deploy_docs
+      if: github.event_name != 'pull_request'
       env:
         GH_USER: github-actions
         GH_EMAIL: "github-action@users.noreply.github.com"


### PR DESCRIPTION
Add back the if condition to only deploy docs on merge, not for PRs.