### PR TITLE
Build CI docs from environment.yml

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -46,6 +46,7 @@ jobs:
 
     - name: build_docs
       run: |
+        conda activate mda-user-guide
         make -C ${SPHINX_DIR} html
 
     - name: deploy_docs

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -14,8 +14,6 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CONDA_DEPS: "jupyter_contrib_nbextensions nglview sphinx ipywidgets matplotlib==3.2.2 MDAnalysis MDAnalysisTests plotly"
-  PIP_DEPS: "sphinx_rtd_theme sphinx-sitemap nbsphinx ipython tabulate sphinxcontrib-bibtex pybtex msmb_theme==1.2.0"
   SPHINX_DIR: "doc/"
   HTML_DIR: "doc/build/html"
 
@@ -42,8 +40,8 @@ jobs:
 
     - name: install_deps
       run: |
-        conda install ${{ env.CONDA_DEPS }}
-        pip install ${{ env.PIP_DEPS }}
+        conda env create -f environment.yml
+        conda activate mda-user-guide
         jupyter-nbextension enable nglview --py --sys-prefix
 
     - name: build_docs

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - pip
   - plotly
   - pybtex
-  - sphinx==2.2.0
+  - sphinx
   - sphinxcontrib-bibtex
   - sphinx_rtd_theme
   - tabulate

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: mda-user-guide
 channels:
+  - defaults
   - conda-forge
   - plotly
 dependencies:


### PR DESCRIPTION
We now don't use astropy/ci-helpers, so... maybe we can magically build from ``environment.yml`` now?