### PR TITLE
Activate mda-user-guide environment in conda

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -37,10 +37,11 @@ jobs:
         channels: plotly, conda-forge
         add-pip-as-python-dependency: true
         architecture: x64
+        environment-file: environment.yml
+        activate-environment: mda-user-guide
 
     - name: install_deps
       run: |
-        conda install -f environment.yml
         jupyter-nbextension enable nglview --py --sys-prefix
 
     - name: build_docs

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -40,13 +40,11 @@ jobs:
 
     - name: install_deps
       run: |
-        conda env create -f environment.yml
-        conda activate mda-user-guide
+        conda install -f environment.yml
         jupyter-nbextension enable nglview --py --sys-prefix
 
     - name: build_docs
       run: |
-        conda activate mda-user-guide
         make -C ${SPHINX_DIR} html
 
     - name: deploy_docs


### PR DESCRIPTION
Install packages from environment.yml into the base environment instead, because it's a bit annoying to activate `mda-user-guide`.