### PR TITLE
Pin sphinx and sphinx_rtd_theme for search

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,9 +17,9 @@ dependencies:
   - pip
   - plotly
   - pybtex
-  - sphinx
+  - sphinx==3.4.2
   - sphinxcontrib-bibtex<2.0.0
-  - sphinx_rtd_theme
+  - sphinx_rtd_theme==0.5.1
   - tabulate
   - pip:
       - msmb_theme==1.2.0


### PR DESCRIPTION
Search works locally, let's see how it does on master.

Fixes #140

I pinned sphinx=3.4.2 and sphinx_rtd_theme=0.5.1 after seeing several issues about Search hanging because of sphinx/rtd mismatch and thanks to https://github.com/readthedocs/sphinx_rtd_theme/pull/346#issuecomment-754869143