### PR TITLE
Pin jinja2 version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - sphinx_rtd_theme==0.5.2
   - tabulate==0.8.7
   - widgetsnbextension==3.5.1
+  - Jinja2==2.11
   - pip:
       - msmb_theme==1.2.0
       - sphinx-sitemap==1.0.2


### PR DESCRIPTION
Currently CI is failing on `develop`: https://github.com/MDAnalysis/UserGuide/pull/126

Let's see if pinning jinja2 fixes this.