### PR TITLE
Add UserGuide example of custom compiler flags  march=native build

### DIFF
--- a/doc/source/AUTHORS
+++ b/doc/source/AUTHORS
@@ -28,3 +28,5 @@ Chronological list of authors
   - Irfan Alibay
   - Yuxuan Zhuang
   - Mieczyslaw Torchala
+2021
+  - Hugo MacDermott-Opeskin

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -158,7 +158,7 @@ Full dicussion of the these flags is available elsewhere and a list of supported
 
 .. warning::
     Use of these compiler options is considered **advanced** and may reduce the binary compatibility of MDAnalysis significantly, especially if using `-march`,
-    making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the testsuite on your intended platform
+    making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the test suite on your intended platform
     before proceeding.
 
 For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -136,7 +136,7 @@ Custom compiler flags and optimised installations
 You can pass any additional compiler flags for the C/C++ compiler using the ``extra_cflags`` variable in ``setup.cfg``.
 This allows you to add any additional compiler options required for your architecture. 
 
-This option can also be used to tune your MDAnalysis installation for your current architecture using `-march`, `-mtune`, `-mcpu` and related compiler flags.
+For example, ``extra_cflags`` can also be used to tune your MDAnalysis installation for your current architecture using the `-march`, `-mtune`, `-mcpu` and related compiler flags.
 The use of these compiler flags allows CPU architecture specific optimisations. An example for an x86_64 machine would be to change the
 
 .. code-block:: YAML

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -143,7 +143,7 @@ Use of this option will result in performance gains where data and pipelining de
 
 .. warning::
     Use of this option is considered **advanced** and will reduce the binary compatibility of MDAnalysis significantly,
-    making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** reccomend that you run the testsuite on your intended platform.
+    making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the testsuite on your intended platform
     before proceeding.
 
 For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -136,7 +136,11 @@ Optimised installations for specific CPU architectures
 An experimental option for compiling the C/C++ in MDAnalysis with architecture specific optimisations enabled has been developed.
 
 This can be activated by uncommenting the "march=native" option in `setup.cfg` and will result in the compiler using CPU architecture specific
-optimisations on x86_64 (equivalent of `-march=native` compiler flag) and ARM platforms (equivalent of `-mcpu=native` compiler flag).
+optimisations on x86_64 (equivalent of `-march=native` compiler flag), ARM platforms (equivalent of `-mcpu=native` compiler flag)
+and PowerPC platforms (equivalent of `-mcpu=native` and `-mtune=native` compiler flag).
+
+If you wish to build for a **specific** architecture, rather than using compiler detection, you can replace `native` with the architecture of your choice.
+A full list of supported options should be provided by your compiler. The list for GCC_ is provided here: 
 
 Note that currently, no additional optimisations are applied on Windows or if using an MSVC compiler.
 Use of this option will result in performance gains where data and pipelining dependencies can be easily identified by the compiler and autovectorisation applied.
@@ -165,5 +169,5 @@ This installation does not download all the datasets; instead, the datasets are 
 
 
 .. _`HOLE`: http://www.holeprogram.org
-.. _mdanalysisdata: https://www.mdanalysis.org/MDAnalysisData/
-
+.. _GCC: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+.. _mdanalysisdata: https://www.mdanalysis.org/MDAnalysisData

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -143,7 +143,8 @@ Use of this option will result in performance gains where data and pipelining de
 
 .. warning::
     Use of this option is considered **advanced** and will reduce the binary compatibility of MDAnalysis significantly,
-    making it usable only on a matching CPU architecture to the one it is compiled on.
+    making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** reccomend that you run the testsuite on your intended platform.
+    before proceeding.
 
 For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the
 compute node you run MDAnalysis on have different CPU architectures, you should avoid this option, or you should compile directly on the compute node.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -137,7 +137,7 @@ You can pass any additional compiler flags for the C/C++ compiler using the ``ex
 This allows you to add any additional compiler options required for your architecture. 
 
 For example, ``extra_cflags`` can also be used to tune your MDAnalysis installation for your current architecture using the `-march`, `-mtune`, `-mcpu` and related compiler flags.
-The use of these compiler flags allows CPU architecture specific optimisations. An example for an x86_64 machine would be to change the
+*Which* particular compiler flags to use depends on your CPU architecture. An example for an x86_64 machine would be to change the
 
 .. code-block:: YAML
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -130,6 +130,23 @@ The plugin `pytest-xdist <https://github.com/pytest-dev/pytest-xdist>`_ can be u
     pip install pytest-xdist
     pytest --disable-pytest-warnings --pyargs MDAnalysisTests --numprocesses 4
 
+Optimised installations for specific CPU architectures
+------------------------------------------------------
+
+An experimental option for compiling the C/C++ in MDAnalysis with architecture specific optimisations enabled has been developed.
+
+This can be activated by uncommenting the "march=native" option in `setup.cfg` and will result in the compiler using CPU architecture specific
+optimisations on x86_64 (equivalent of `-march=native` compiler flag) and ARM platforms (equivalent of `-mcpu=native` compiler flag).
+
+Note that currently, no additional optimisations are applied on Windows or if using an MSVC compiler.
+Use of this option will result in performance gains where data and pipelining dependencies can be easily identified by the compiler and autovectorisation applied.
+
+.. warning::
+    Use of this option is considered **advanced** and will reduce the binary compatibility of MDAnalysis significantly,
+    making it usable only on a matching CPU architecture to the one it is compiled on.
+
+For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the
+compute node you run MDAnalysis on have different CPU architectures, you should avoid this option, or you should compile directly on the compute node.
 
 Additional datasets
 ===================
@@ -148,3 +165,4 @@ This installation does not download all the datasets; instead, the datasets are 
 
 .. _`HOLE`: http://www.holeprogram.org
 .. _mdanalysisdata: https://www.mdanalysis.org/MDAnalysisData/
+

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -159,7 +159,7 @@ Full dicussion of the these flags is available elsewhere and a list of supported
 .. warning::
     Use of these compiler options is considered **advanced** and may reduce the binary compatibility of MDAnalysis significantly, especially if using `-march`,
     making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the test suite on your intended platform
-    before proceeding.
+    before proceeding with analysis.
 
 For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the
 compute node you run MDAnalysis on have different CPU architectures, you should avoid this option unless you know what you are doing, or you should compile directly on the compute node.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -136,7 +136,7 @@ Custom compiler flags and optimised installations
 You can pass any additional compiler flags for the C/C++ compiler using the ``extra_cflags`` variable in ``setup.cfg``.
 This allows you to add any additional compiler options required for your architecture. 
 
-For example, ``extra_cflags`` can also be used to tune your MDAnalysis installation for your current architecture using the `-march`, `-mtune`, `-mcpu` and related compiler flags.
+For example, ``extra_cflags`` can be used to tune your MDAnalysis installation for your current architecture using the `-march`, `-mtune`, `-mcpu` and related compiler flags.
 *Which* particular compiler flags to use depends on your CPU architecture. An example for an x86_64 machine would be to change the line in `setup.cfg` as follows:
 
 .. code-block:: diff

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -151,7 +151,7 @@ line in `setup.cfg` to instead be:
 
 Use of these flags can give a significant performance boost where the compiler can effectively autovectorise.
 
-Be sure to use the recommended flags for your target architecture. For example, ARM platforms reccomend against the use of `-mtune` in favour of `-mcpu`, while
+Be sure to use the recommended flags for your target architecture. For example, ARM platforms recommend using ``-mcpu`` *instead* of ``-mcpu``, while
 PowerPC platforms prefer both `-mcpu` and `-mtune`.
 
 Full dicussion of the these flags is available elsewhere and a list of supported options should be provided by your compiler. The list for GCC_ is provided here. 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -152,7 +152,7 @@ line in `setup.cfg` to instead be:
 Use of these flags can give a significant performance boost where the compiler can effectively autovectorise.
 
 Be sure to use the recommended flags for your target architecture. For example, ARM platforms recommend using ``-mcpu`` *instead* of ``-mcpu``, while
-PowerPC platforms prefer both `-mcpu` and `-mtune`.
+PowerPC platforms prefer *both* ``-mcpu`` and ``-mtune``.
 
 Full dicussion of the these flags is available elsewhere and a list of supported options should be provided by your compiler. The list for GCC_ is provided here. 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -133,7 +133,7 @@ The plugin `pytest-xdist <https://github.com/pytest-dev/pytest-xdist>`_ can be u
 Custom compiler flags and optimised installations
 -------------------------------------------------
 
-You can pass any additional compiler flags for the C/C++ compiler using the `extra_cflags` variable in `setup.cfg`.
+You can pass any additional compiler flags for the C/C++ compiler using the ``extra_cflags`` variable in ``setup.cfg``.
 This allows you to add any additional compiler options required for your architecture. 
 
 This option can also be used to tune your MDAnalysis installation for your current architecture using `-march`, `-mtune`, `-mcpu` and related compiler flags.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -130,28 +130,39 @@ The plugin `pytest-xdist <https://github.com/pytest-dev/pytest-xdist>`_ can be u
     pip install pytest-xdist
     pytest --disable-pytest-warnings --pyargs MDAnalysisTests --numprocesses 4
 
-Optimised installations for specific CPU architectures
-------------------------------------------------------
+Custom compiler flags and optimised installations
+-------------------------------------------------
 
-An experimental option for compiling the C/C++ in MDAnalysis with architecture specific optimisations enabled has been developed.
+You can pass any additional compiler flags for the C/C++ compiler using the `extra_cflags` variable in `setup.cfg`.
+This allows you to add any additional compiler options required for your architecture. 
 
-This can be activated by uncommenting the "march=native" option in `setup.cfg` and will result in the compiler using CPU architecture specific
-optimisations on x86_64 (equivalent of `-march=native` compiler flag), ARM platforms (equivalent of `-mcpu=native` compiler flag)
-and PowerPC platforms (equivalent of `-mcpu=native` and `-mtune=native` compiler flag).
+This option can also be used to tune your MDAnalysis installation for your current architecture using `-march`, `-mtune`, `-mcpu` and related compiler flags.
+The use of these compiler flags allows CPU architecture specific optimisations. An example for an x86_64 machine would be to change the
 
-If you wish to build for a **specific** architecture, rather than using compiler detection, you can replace `native` with the architecture of your choice.
-A full list of supported options should be provided by your compiler. The list for GCC_ is provided here: 
+.. code-block:: YAML
 
-Note that currently, no additional optimisations are applied on Windows or if using an MSVC compiler.
-Use of this option will result in performance gains where data and pipelining dependencies can be easily identified by the compiler and autovectorisation applied.
+    #extra_cflags =
+
+line in `setup.cfg` to instead be:
+
+.. code-block:: YAML
+
+    extra_cflags = -march=native -mtune=native
+
+Use of these flags can give a significant performance boost where the compiler can effectively autovectorise.
+
+Be sure to use the recommended flags for your target architecture. For example, ARM platforms reccomend against the use of `-mtune` in favour of `-mcpu`, while
+PowerPC platforms prefer both `-mcpu` and `-mtune`.
+
+Full dicussion of the these flags is available elsewhere and a list of supported options should be provided by your compiler. The list for GCC_ is provided here. 
 
 .. warning::
-    Use of this option is considered **advanced** and will reduce the binary compatibility of MDAnalysis significantly,
+    Use of these compiler options is considered **advanced** and may reduce the binary compatibility of MDAnalysis significantly, especially if using `-march`,
     making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the testsuite on your intended platform
     before proceeding.
 
 For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the
-compute node you run MDAnalysis on have different CPU architectures, you should avoid this option, or you should compile directly on the compute node.
+compute node you run MDAnalysis on have different CPU architectures, you should avoid this option unless you know what you are doing, or you should compile directly on the compute node.
 
 Additional datasets
 ===================

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -161,8 +161,7 @@ Full dicussion of the these flags is available elsewhere and a list of supported
     making it usable only on a matching CPU architecture to the one it is compiled on. We **strongly** recommend that you run the test suite on your intended platform
     before proceeding with analysis.
 
-For example, if you plan on using MDAnalysis on a heterogenous system, such as a supercomputer, where the login node you compile on and the
-compute node you run MDAnalysis on have different CPU architectures, you should avoid this option unless you know what you are doing, or you should compile directly on the compute node.
+In cases where you might encounter multiple CPU architectures (e.g. on a supercomputer where the login node and compute node have different architectures), you should avoid changing these options unless you are experienced with compiling software in these situations.
 
 Additional datasets
 ===================

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -137,24 +137,19 @@ You can pass any additional compiler flags for the C/C++ compiler using the ``ex
 This allows you to add any additional compiler options required for your architecture. 
 
 For example, ``extra_cflags`` can also be used to tune your MDAnalysis installation for your current architecture using the `-march`, `-mtune`, `-mcpu` and related compiler flags.
-*Which* particular compiler flags to use depends on your CPU architecture. An example for an x86_64 machine would be to change the
+*Which* particular compiler flags to use depends on your CPU architecture. An example for an x86_64 machine would be to change the line in `setup.cfg` as follows:
 
-.. code-block:: YAML
+.. code-block:: diff
 
-    #extra_cflags =
-
-line in `setup.cfg` to instead be:
-
-.. code-block:: YAML
-
-    extra_cflags = -march=native -mtune=native
+	- #extra_cflags = 
+	+ extra_cflags = -march=native -mtune=native
 
 Use of these flags can give a significant performance boost where the compiler can effectively autovectorise.
 
 Be sure to use the recommended flags for your target architecture. For example, ARM platforms recommend using ``-mcpu`` *instead* of ``-mcpu``, while
 PowerPC platforms prefer *both* ``-mcpu`` and ``-mtune``.
 
-Full dicussion of the these flags is available elsewhere and a list of supported options should be provided by your compiler. The list for GCC_ is provided here. 
+Full dicussion of the these flags is available elsewhere (such as here in this wiki_ or in this ARM_ blog post) and a list of supported options should be provided by your compiler. The list for GCC_ is provided here. 
 
 .. warning::
     Use of these compiler options is considered **advanced** and may reduce the binary compatibility of MDAnalysis significantly, especially if using `-march`,
@@ -181,3 +176,5 @@ This installation does not download all the datasets; instead, the datasets are 
 .. _`HOLE`: http://www.holeprogram.org
 .. _GCC: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
 .. _mdanalysisdata: https://www.mdanalysis.org/MDAnalysisData
+.. _wiki: https://wiki.gentoo.org/wiki/GCC_optimization#-march
+.. _ARM: https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu


### PR DESCRIPTION
Introduction of the possibility of using the "march=native" build option in setup.cfg properly (see https://github.com/MDAnalysis/mdanalysis/pull/3429) means that we need some documentation to match.

It is critical to explain why this option is advanced and potential pitfalls, hence the warning and example.

NB do not merge if/until PR in MDA core is merged. 