### PR TITLE
Switch dependencies to latest release of MDAnalysis

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,8 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - mdanalysis
+  - mdanalysistests
   - cython
   - dask
   - decorator==4.4.2
@@ -40,5 +42,3 @@ dependencies:
   - pip:
       - msmb_theme==1.2.0
       - sphinx-sitemap==1.0.2
-      - git+https://github.com/MDAnalysis/mdanalysis@develop#egg=mdanalysis&subdirectory=package
-      - git+https://github.com/MDAnalysis/mdanalysis@develop#egg=MDAnalysisTests&subdirectory=testsuite


### PR DESCRIPTION
After merging `develop`, the dependencies were updated to the develop version of MDAnalysis; this PR reverts that.