### PR TITLE
Update release notes to match the new release mechanism

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         auto-update-conda: true
         channel-priority: flexible
         channels: plotly, conda-forge


### PR DESCRIPTION
This matches how releases will happen once the following PR is merged: https://github.com/MDAnalysis/mdanalysis/pull/3680

It also matches the MDAnalysis wiki notes: https://github.com/MDAnalysis/mdanalysis/wiki/PreparingReleases