### PR TITLE
Deploy non-dev userguide on tag

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - develop
       - master
+    tags:
+      - "release-*"
   pull_request:
     branches:
       - develop
@@ -11,8 +13,6 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-  tags:
-    - "release-*"
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -11,6 +11,8 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
+  tags:
+    - "release-*"
 
 concurrency:
   # Probably overly cautious group naming.
@@ -53,6 +55,11 @@ jobs:
     - name: install_deps
       run: |
         jupyter-nbextension enable nglview --py --sys-prefix
+
+    - name: install_released_mda
+      # If it's a release, pick up the latest version of MDAnalysis/Tests and deploy that
+      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release'))
+      run: python -m pip install MDAnalysis MDAnalysisTests
 
     - name: build_docs
       run: |


### PR DESCRIPTION
I tried to make it complicated and then realised it wasn't necessary.

This just installs the non-dev version of MDA/Tests on tag and pushes the userguide up.

Fixes our need to merge `master` in?