### PR TITLE
Fix deploy on tag workflow

### DIFF
--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           auto-update-conda: True
           use-mamba: True
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
           miniforge-variant: Mambaforge
           environment-file: environment.yml
           activate-environment: mda-user-guide

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         auto-update-conda: true
         miniforge-variant: Mambaforge
         use-mamba: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -60,7 +60,7 @@ jobs:
     - name: install_released_mda
       # If it's a release, pick up the latest version of MDAnalysis/Tests and deploy that
       if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release'))
-      run: python -m pip install MDAnalysis MDAnalysisTests
+      run: python -m pip install MDAnalysis MDAnalysisTests -U --force-reinstall
 
     - name: build_docs
       run: |


### PR DESCRIPTION
I think some changes in the pip behavious made is such that the release install wouldn't override the dev0 version installed. So to go around this, we instead force a reinstall which should make it pick up whatever is on pypi.