### PR TITLE
ci: migrate to setup-micromamba

### DIFF
--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -30,15 +30,18 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: setup micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v16
         with:
           environment-file: environment.yml
-          environmentt-name: mda-user-guide
-          extra-specs: |
+          environment-name: mda-user-guide
+          create-args: >- 
             python==3.9
             hole2
             pip
-          channels: conda-forge, plotly
+          condarc: |
+            channels:
+              - conda-forge
+              - plotly
 
       - name: "environment information"
         run: |

--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: setup micromamba
-        uses: mamba-org/setup-micromamba@v16
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           environment-name: mda-user-guide

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -40,14 +40,17 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: setup micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v16
       with:
         environment-file: environment.yml
-        environmentt-name: mda-user-guide
-        extra-specs: |
-          python==3.9
+        environment-name: mda-user-guide
+        create-args: >- 
+          python=3.9
           pip
-        channels: conda-forge, plotly
+        condarc: |
+          channels:
+            - conda-forge
+            - plotly
 
     - name: install_deps
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: setup micromamba
-      uses: mamba-org/setup-micromamba@v16
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml
         environment-name: mda-user-guide


### PR DESCRIPTION
Apologies I didn't open a ticket – happy to do so, if that's the process you follow in this repo. 

This is a "good scout" change, because I stumbled upon a deprecation in the other PR https://github.com/MDAnalysis/UserGuide/pull/264

So in this PR, I migrate to a maintained GH action for the micromamba. All the current builds display the following warning

```
Warning: Unexpected input(s) 'environmentt-name', valid inputs are ['environment-file', 'environment-name', 'micromamba-version', 'extra-specs', 'channels', 'condarc-file', 'channel-priority', 'cache-downloads', 'cache-downloads-key', 'cache-env', 'cache-env-key', 'log-level', 'installer-url', 'condarc-options', 'post-deinit']
Run mamba-org/provision-with-micromamba@main
Warning: This action is deprecated and no longer maintained. Please use mamba-org/setup-micromamba instead. See `[https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba`](https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60) for a migration guide.