### PR TITLE
fix: warnings when running 'make html'

### DIFF
--- a/doc/source/examples/other/parmed_sim.ipynb
+++ b/doc/source/examples/other/parmed_sim.ipynb
@@ -550,6 +550,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "[1] R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler, D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein. [MDAnalysis: A Python package for the rapid analysis of molecular dynamics simulations](http://conference.scipy.org/proceedings/scipy2016/oliver_beckstein.html). In S. Benthall and S. Rostrup, editors, *Proceedings of the 15th Python in Science Conference*, pages 98-105, Austin, TX, 2016. SciPy, doi: [10.25080/majora-629e541a-00e](https://doi.org/10.25080/majora-629e541a-00e).\n",
     "\n",
     "[2] N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein. MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations. *J. Comput. Chem*. 32 (2011), 2319-2327, [doi:10.1002/jcc.21787](https://dx.doi.org/10.1002/jcc.21787). PMCID:[PMC3144279](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3144279/)\n",

--- a/doc/source/references.bib
+++ b/doc/source/references.bib
@@ -559,3 +559,15 @@
 	abstract = {Abstract Helical conformations of infinite polymer chains may be described by the helical parameters, d and θ (the translation along the helix axis and the angle of rotation about the axis per repeat unit), pi (the distance of the ith atom from the axis), dij, and dij (the translation along the axis and the angle of rotation, respectively, on passing from the ith atom to the jth). A general method has been worked out for calculating all those helical parameters from the bond lengths, bond angles, and internal-rotation angles. The positions of the main chain and side chain atoms with respect to the axis may also be calculated. All the equations are applicable to any helical polymer chain and are readily programmed for electronic computers. A method is also presented for calculating the partial derivatives of helical parameters with respect to molecular parameters.},
 	year = {1967}
 }
+
+@book{Gray1984,
+	address = {Oxford ; New York},
+	series = {The {International} series of monographs on chemistry},
+	title = {Theory of molecular fluids},
+	isbn = {978-0-19-855602-2},
+	number = {9},
+	publisher = {Oxford University Press},
+	author = {Gray, C. G. and Gubbins, Keith E. and Joslin, C. G.},
+	year = {1984},
+	keywords = {Fluids, Molecular theory},
+}


### PR DESCRIPTION
A very minor PR, fixes two warning messages that appear when running 'make html'

```
/Users/jandom/workspace/MDAnalysis/UserGuide/doc/source/examples/other/parmed_sim.ipynb:21: WARNING: undefined label: '/examples/other/parmed_sim.ipynb#references'
```

And the missing reference

```
/Users/jandom/workspace/MDAnalysis/UserGuide/doc/source/generated/topology/groupmethods.txt:11: WARNING: could not find bibtex key "Gray1984"
```