### PR TITLE
ci: enable micromamba env cache

### DIFF
--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -35,7 +35,6 @@ jobs:
           environment-file: environment.yml
           environment-name: mda-user-guide
           cache-environment: true
-          cache-environment-key: gh-ci-tests
           create-args: >-
             hole2
 

--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -36,14 +36,6 @@ jobs:
           environment-name: mda-user-guide
           cache-environment: true
           cache-environment-key: gh-ci-tests
-          create-args: >- 
-            python==3.9
-            hole2
-            pip
-          condarc: |
-            channels:
-              - conda-forge
-              - plotly
 
       - name: "environment information"
         run: |

--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -35,6 +35,7 @@ jobs:
           environment-file: environment.yml
           environment-name: mda-user-guide
           cache-environment: true
+          cache-environment-key: gh-ci-tests
           create-args: >- 
             python==3.9
             hole2

--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: mda-user-guide
+          cache-environment: true
           create-args: >- 
             python==3.9
             hole2

--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -36,6 +36,8 @@ jobs:
           environment-name: mda-user-guide
           cache-environment: true
           cache-environment-key: gh-ci-tests
+          create-args: >-
+            hole2
 
       - name: "environment information"
         run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -46,13 +46,6 @@ jobs:
         environment-name: mda-user-guide
         cache-environment: true
         cache-environment-key: gh-ci
-        create-args: >- 
-          python=3.9
-          pip
-        condarc: |
-          channels:
-            - conda-forge
-            - plotly
 
     - name: install_deps
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,6 +45,7 @@ jobs:
         environment-file: environment.yml
         environment-name: mda-user-guide
         cache-environment: true
+        cache-environment-key: gh-ci
         create-args: >- 
           python=3.9
           pip

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -44,6 +44,7 @@ jobs:
       with:
         environment-file: environment.yml
         environment-name: mda-user-guide
+        cache-environment: true
         create-args: >- 
           python=3.9
           pip

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,7 +45,6 @@ jobs:
         environment-file: environment.yml
         environment-name: mda-user-guide
         cache-environment: true
-        cache-environment-key: gh-ci
 
     - name: install_deps
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: guide
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
+  - plotly
   - defaults
 dependencies:
   - cython
@@ -33,7 +34,7 @@ dependencies:
   - pip
   - plotly
   - pybtex
-  - python
+  - python=3.9
   - pyvista
   - scikit-image
   - scikit-learn>=1.1.2


### PR DESCRIPTION
The micromamba environment creation takes about 5 minutes and is more than the actual build step (2 mins for buliding docs). Here is an example run

https://github.com/MDAnalysis/UserGuide/actions/runs/5622842883/job/15236245154

This is not ideal – developers want to see a crisp output of their work. 

I'm not sure how to enable this feature, or how well it works, so using this branch to experiment. If it works well, maybe we can consider porting to MDA core?

**Update** Here are some preliminary results showing the impact on the build speed, with and without caching

| Workflow Name | Caching on/off | Setup Duration | Job Duration |
|--------|--------|--------|--------|
| [mda_gh_ci](https://github.com/MDAnalysis/UserGuide/actions/runs/5623009172/attempts/1?pr=273) | Off | 4m 39s | 6m 16s |
| [mda_gh_ci](https://github.com/MDAnalysis/UserGuide/actions/runs/5623009172/attempts/2?pr=273) | On | 21s | 2m 6s |
| [mda_gh_ci_tests](https://github.com/MDAnalysis/UserGuide/actions/runs/5623009170/attempts/1?pr=273) | Off | 6m 29s | 16m 39s | 
| [mda_gh_ci_tests](https://github.com/MDAnalysis/UserGuide/actions/runs/5623009170/attempts/2?pr=273) | On | 27s | 15m 26s | 