### PR TITLE
fix: broken sitemap links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,7 +96,7 @@ todo_include_todos = True
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
-site_url = "https://userguide.mdanalysis.org/"
+html_baseurl = "https://userguide.mdanalysis.org/"
 sitemap_url_scheme = "{link}"
 html_use_opensearch = 'https://userguide.mdanalysis.org'
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,8 +96,7 @@ todo_include_todos = True
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
-site_url = "https://userguide.mdanalysis.org"
-html_baseurl = "https://userguide.mdanalysis.org/"
+site_url = "https://userguide.mdanalysis.org/"
 sitemap_url_scheme = "{link}"
 html_use_opensearch = 'https://userguide.mdanalysis.org'
 


### PR DESCRIPTION
Maybe fixes #172 – it worked for me locally (MacOS), and the sitemap.xml file looked sane – but I don't know enough about how this works to confidently say "this won't break something else"

[sitemap.xml.txt](https://github.com/MDAnalysis/UserGuide/files/12165055/sitemap.xml.txt)
