### PR TITLE
dev: run isort via pre-commit

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,11 +14,12 @@
 # import sys
 
 import datetime
-from collections import OrderedDict
-import MDAnalysis as mda
 import subprocess
-import sphinx_rtd_theme
+from collections import OrderedDict
+
+import MDAnalysis as mda
 import msmb_theme
+import sphinx_rtd_theme
 from ipywidgets.embed import DEFAULT_EMBED_REQUIREJS_URL
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/scripts/base.py
+++ b/doc/source/scripts/base.py
@@ -1,11 +1,13 @@
 
 from __future__ import print_function
-import sys
+
 import os
 import pathlib
-import tabulate
+import sys
 import textwrap
 from collections import defaultdict
+
+import tabulate
 
 
 class TableWriter(object):

--- a/doc/source/scripts/clean_example_notebooks.py
+++ b/doc/source/scripts/clean_example_notebooks.py
@@ -22,23 +22,22 @@ References
 This script uses the sphinxcontrib-bibtex extension for references.
 """
 
-import os
-import glob
+import argparse
 import datetime
+import glob
+import logging
+import os
 import re
 import shutil
-import argparse
-import logging
 import sys
 
-import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
-import pybtex as tex
-from pybtex.database import parse_file, BibliographyData
-import pybtex.plugin
-from pybtex.style import formatting
-
 import MDAnalysis as mda
+import nbformat
+import pybtex as tex
+import pybtex.plugin
+from nbconvert.preprocessors import ExecutePreprocessor
+from pybtex.database import BibliographyData, parse_file
+from pybtex.style import formatting
 
 parser = argparse.ArgumentParser(description='Clean Jupyter notebooks.')
 parser.add_argument('files', type=str, nargs='+', help='notebook files')

--- a/doc/source/scripts/core.py
+++ b/doc/source/scripts/core.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
+
 import os
+
 import tabulate
 from MDAnalysis import _TOPOLOGY_ATTRS
 

--- a/doc/source/scripts/gen_format_overview_classes.py
+++ b/doc/source/scripts/gen_format_overview_classes.py
@@ -8,9 +8,9 @@ Generates:
 
 from collections import defaultdict
 
-from MDAnalysis import _READERS, _SINGLEFRAME_WRITERS, _PARSERS, _CONVERTERS
 from base import TableWriter
 from core import DESCRIPTIONS
+from MDAnalysis import _CONVERTERS, _PARSERS, _READERS, _SINGLEFRAME_WRITERS
 
 FILE_TYPES = defaultdict(dict)
 

--- a/doc/source/scripts/gen_selection_exporters.py
+++ b/doc/source/scripts/gen_selection_exporters.py
@@ -4,8 +4,8 @@ Generates:
     - ../formats/selection_exporters.txt
 """
 
-from MDAnalysis import _SELECTION_WRITERS
 from base import TableWriter
+from MDAnalysis import _SELECTION_WRITERS
 
 SELECTION_DESCRIPTIONS = {
     'vmd': 'VMD macros, available in Representations',

--- a/doc/source/scripts/gen_standard_selections.py
+++ b/doc/source/scripts/gen_standard_selections.py
@@ -11,6 +11,7 @@ Writes standard selection names for:
 from base import TableWriter
 from MDAnalysis.core import selection as sel
 
+
 def chunk_list(lst, n=8):
     return [lst[i:i+n] for i in range(0, len(lst), n)]
 

--- a/doc/source/scripts/gen_topology_groupmethods.py
+++ b/doc/source/scripts/gen_topology_groupmethods.py
@@ -6,9 +6,10 @@ A table of transplanted methods.
 """
 
 from collections import defaultdict
-from MDAnalysis.core.groups import GroupBase
+
 from base import TableWriter
 from core import TOPOLOGY_CLS
+from MDAnalysis.core.groups import GroupBase
 
 
 class TransplantedMethods(TableWriter):

--- a/doc/source/scripts/gen_topologyattr_defaults.py
+++ b/doc/source/scripts/gen_topologyattr_defaults.py
@@ -5,10 +5,9 @@ Generate topology_defaults.txt:
 A table of whether TopologyAttrs are atomwise, residuewise, or segmentwise, and their defaults
 """
 
-from MDAnalysis.core.topologyattrs import AtomAttr, ResidueAttr, SegmentAttr
-from core import TOPOLOGY_CLS
 from base import TableWriter
-
+from core import TOPOLOGY_CLS
+from MDAnalysis.core.topologyattrs import AtomAttr, ResidueAttr, SegmentAttr
 
 DEFAULTS = {
     'resids': 'continuous sequence from 1 to n_residues',

--- a/doc/source/scripts/gen_topologyparser_attrs.py
+++ b/doc/source/scripts/gen_topologyparser_attrs.py
@@ -10,12 +10,13 @@ This script imports the testsuite, which tests these.
 import os
 import sys
 from collections import defaultdict
-from core import DESCRIPTIONS, NON_CORE_ATTRS
-from base import TableWriter
 
+from base import TableWriter
+from core import DESCRIPTIONS, NON_CORE_ATTRS
 from MDAnalysisTests.topology.base import mandatory_attrs
 from MDAnalysisTests.topology.test_crd import TestCRDParser
-from MDAnalysisTests.topology.test_dlpoly import TestDLPHistoryParser, TestDLPConfigParser
+from MDAnalysisTests.topology.test_dlpoly import (TestDLPConfigParser,
+                                                  TestDLPHistoryParser)
 from MDAnalysisTests.topology.test_dms import TestDMSParser
 from MDAnalysisTests.topology.test_fhiaims import TestFHIAIMS
 from MDAnalysisTests.topology.test_gms import GMSBase
@@ -34,7 +35,6 @@ from MDAnalysisTests.topology.test_tprparser import TPRAttrs
 from MDAnalysisTests.topology.test_txyz import TestTXYZParser
 from MDAnalysisTests.topology.test_xpdb import TestXPDBParser
 from MDAnalysisTests.topology.test_xyz import XYZBase
-
 
 PARSER_TESTS = (TestCRDParser, TestDLPHistoryParser, TestDLPConfigParser,
                 TestDMSParser, TestFHIAIMS, GMSBase,

--- a/doc/source/scripts/gen_unit_tables.py
+++ b/doc/source/scripts/gen_unit_tables.py
@@ -4,8 +4,9 @@ Writes unit tables
 """
 import pathlib
 import sys
-import tabulate
 import textwrap
+
+import tabulate
 from MDAnalysis.units import conversion_factor
 
 

--- a/maintainer/update_json_stubs_sitemap.py
+++ b/maintainer/update_json_stubs_sitemap.py
@@ -9,14 +9,13 @@
 #  3. Write a sitemap.xml file for the root directory
 #
 
+import errno
+import glob
 import json
 import os
 import shutil
-import xml.etree.ElementTree as ET
-import errno
-import glob
 import textwrap
-import shutil
+import xml.etree.ElementTree as ET
 
 try:
     from urllib.request import Request, urlopen


### PR DESCRIPTION
Having standardized import sorting is really, really nice, because everything becomes consistent. isort deals with import sorting. all changes in this PR are automated code changes. Goes hand-in-hand with another PR, that actually modifies the config https://github.com/MDAnalysis/UserGuide/pull/284