### PR TITLE
dev: add isort to pre commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # https://github.com/MDAnalysis/UserGuide/pull/281
 87210209ab00ad7257fa7df2c06e8b4caa579e26
+# https://github.com/MDAnalysis/UserGuide/pull/283
+5ff083b144c37beb64b27600add967c8a73766ce

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
         exclude: ^.*\.(pdb)$
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)


### PR DESCRIPTION
follow-up to https://github.com/MDAnalysis/UserGuide/pull/283 which adds isort to pre-commit