### PR TITLE
refactor: remove dead code

### DIFF
--- a/doc/source/scripts/base.py
+++ b/doc/source/scripts/base.py
@@ -25,11 +25,8 @@ class TableWriter(object):
     postprocess = []
     sort = True
 
-    def __getattr__(self, key):
-        try:
-            return self.fields[key]
-        except KeyError:
-            return super(TableWriter, self).__getattr__(key)
+    def __getattr__(self, key: str) -> list:
+        return self.fields[key]
 
     def __init__(self, *args, **kwargs):
         stem = os.getcwd().split("source")[0]
@@ -99,10 +96,8 @@ class TableWriter(object):
         return ":meth:`{}{}.{}`".format(prefix, meth.__module__, meth.__qualname__)
 
     @staticmethod
-    def sphinx_ref(txt, label=None, suffix=""):
-        if label is None:
-            label = txt
-        return ":ref:`{} <{}{}>`".format(txt, label, suffix)
+    def sphinx_ref(txt: str, label: str = None, suffix: str = "") -> str:
+        return f":ref:`{txt} <{label}{suffix}>`"
 
     @staticmethod
     def sphinx_link(txt):


### PR DESCRIPTION
snapshot tests in the [other PR](https://github.com/MDAnalysis/UserGuide/pull/285) identified dead code that's never executed, we can safely removed it. The snapshot tests ran all the script code, so there is no risk of missing a code-path. Removing this code will make the code simpler to reason about, and make refactoring easier.