### PR TITLE
Update python setup.py build_sphinx

### DIFF
--- a/doc/source/contributing_code.rst
+++ b/doc/source/contributing_code.rst
@@ -687,7 +687,7 @@ Then, generate the docs with:
 
     .. code-block:: bash
 
-        python setup.py build_sphinx -E
+        cd doc/sphinx && make html
 
 This generates and updates the files in ``doc/html``. If the above command fails with an ``ImportError``, run
 


### PR DESCRIPTION
Fixes #308 

Chooses `make html` over `build_sphinx`, which will be unsupported as of sphinx 7.0. `make html` is much simpler than having to specify the source and destination directories of `sphinx-build`. Since this is just building docs for personal use, I went with the simpler command.

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--310.org.readthedocs.build/en/310/

<!-- readthedocs-preview mdanalysis end -->