### PR TITLE
Pin theme higher

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - scikit-learn>=1.1.2
   - pyedr>=0.7
   # building documentation
-  - mdanalysis-sphinx-theme >=1.0.1
+  - mdanalysis-sphinx-theme >=1.1.0
   - docutils
   - pandoc
   - pybtex


### PR DESCRIPTION
Develop docs are still pulling mda sphinx theme 1.0.1 -- pinning higher to force updates.

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--316.org.readthedocs.build/en/316/

<!-- readthedocs-preview mdanalysis end -->