### PR TITLE
Have the right project slug on the rtd.yaml action

### DIFF
--- a/.github/workflows/rtd.yaml
+++ b/.github/workflows/rtd.yaml
@@ -16,4 +16,4 @@ jobs:
     steps:
     - uses: readthedocs/actions/preview@v1
       with:
-        project-slug: "mdanalysis"
+        project-slug: "UserGuide"

--- a/.github/workflows/rtd.yaml
+++ b/.github/workflows/rtd.yaml
@@ -16,4 +16,4 @@ jobs:
     steps:
     - uses: readthedocs/actions/preview@v1
       with:
-        project-slug: "UserGuide"
+        project-slug: "mdanalysisuserguide"


### PR DESCRIPTION
The action isn't as relevant now that RTD points back to the build by default, but it still helps new users know where the build is (rather than searching through check links).

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--323.org.readthedocs.build/en/323/

<!-- readthedocs-preview mdanalysis end -->