### PR TITLE
Fix typo in gh dicussions target

### DIFF
--- a/doc/source/preparing_releases_and_hotfixes.rst
+++ b/doc/source/preparing_releases_and_hotfixes.rst
@@ -67,7 +67,7 @@ Summary of tasks
 Getting the develop branch ready for a release
 ----------------------------------------------
 
-#. Declare feature freeze on ``develop`` via `discord` and `GitHub Discussions (Anouncement)`_
+#. Declare feature freeze on ``develop`` via `discord` and `GitHub Discussions (Announcement)`_
 
 #. Create a pre-release feature branch from ``develop``
 


### PR DESCRIPTION
From CI:

```
/home/runner/work/UserGuide/UserGuide/doc/source/preparing_releases_and_hotfixes.rst:70: ERROR: Unknown target name: "github discussions (anouncement)".
```

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--351.org.readthedocs.build/en/351/

<!-- readthedocs-preview mdanalysisuserguide end -->