### PR TITLE
Turn off caching

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,6 @@ jobs:
       with:
         environment-file: environment.yml
         environment-name: mda-user-guide
-        cache-environment: true
 
     - name: install_deps
       run: |


### PR DESCRIPTION
Temporary patch for #354 

There's a cache clearing solution here, but for now this will at least avoid us using super old environments.

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--355.org.readthedocs.build/en/355/

<!-- readthedocs-preview mdanalysisuserguide end -->