### PR TITLE
include date in cache key

### DIFF
--- a/.github/workflows/gh-ci-tests.yaml
+++ b/.github/workflows/gh-ci-tests.yaml
@@ -29,12 +29,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+
       - name: setup micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           environment-name: mda-user-guide
           cache-environment: true
+          cache-downloads: true
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
+          cache-downloads-key: downloads-${{ steps.date.outputs.date }}
           create-args: >-
             hole2
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -37,11 +37,20 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+
     - name: setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml
         environment-name: mda-user-guide
+        cache-environment: true
+        cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+
 
     - name: install_deps
       run: |


### PR DESCRIPTION
This will cache the env + the package downloads. The date is included in the cache key so it will never be older than a day. This will still save some time/carbon when running CI, but will ensure that scheduled runs will get a "fresh" env.

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--359.org.readthedocs.build/en/359/

<!-- readthedocs-preview mdanalysisuserguide end -->