### PR TITLE
Update link for GSoD 2019

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ This repository contains the `user guide`_ for MDAnalysis. The user guide origin
 .. _`many popular formats`: https://www.mdanalysis.org/UserGuide/formats/index.html
 .. _MDAnalysis: https://www.mdanalysis.org
 .. _LICENSE: https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE
-.. _`project for Google Season of Docs 2019-2020`: https://developers.google.com/season-of-docs/docs/participants/project-mdanalysis
+.. _`project for Google Season of Docs 2019-2020`: https://developers.google.com/season-of-docs/docs/2019/participants/project-mdanalysis
 
 .. |usergroup| image:: https://img.shields.io/badge/Google%20Group-Users-lightgrey.svg
    :alt: User Google Group

--- a/doc/source/AUTHORS
+++ b/doc/source/AUTHORS
@@ -41,3 +41,5 @@ Chronological list of authors
   - Jan Domanski
   - Micaela Matta
   - Mike Henry
+2024
+  - Mahfuza Humayra Mohona


### PR DESCRIPTION
Updated link for GSoD 2019 in `Readme.rst`.

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--381.org.readthedocs.build/en/381/

<!-- readthedocs-preview mdanalysisuserguide end -->