### PR TITLE
Remove substitution

### DIFF
--- a/doc/source/examples/constructing_universe.ipynb
+++ b/doc/source/examples/constructing_universe.ipynb
@@ -1031,7 +1031,7 @@
     "<center>\n",
     "<div style=\"width:800px; text-align:center;\">\n",
     "\n",
-    "![no_overlap_view](images/constructing-universe_domain-view.png)\n",
+    "![domain-view](images/constructing-universe_domain-view.png)\n",
     "    \n",
     "</div>\n",
     "</center>"


### PR DESCRIPTION
Removed substitution, which was occurring because there was multiple images with the same alt text `no_overlap_view`. 

Closes: #376

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--385.org.readthedocs.build/en/385/

<!-- readthedocs-preview mdanalysisuserguide end -->