### PR TITLE
update psf insertion codes

### DIFF
--- a/doc/source/formats/reference/psf.rst
+++ b/doc/source/formats/reference/psf.rst
@@ -24,9 +24,7 @@ As a NAMD file is space-separated, files with missing columns can cause MDAnalys
 
 .. _`This can cause issues for PSF files written from VMD.`: https://github.com/MDAnalysis/mdanalysis/issues/2061
 
-PSF files can encode insertion codes. However, MDAnalysis `does not currently support reading PSF files with insertion codes`_.
-
-.. _`does not currently support reading PSF files with insertion codes`: https://github.com/MDAnalysis/mdanalysis/issues/2053
+PSF files can encode insertion codes and MDAnalysis will read them.
 
 
 


### PR DESCRIPTION
update notes on PSF file format 

https://github.com/MDAnalysis/mdanalysis/issues/2053 was closed by
PR https://github.com/MDAnalysis/mdanalysis/pull/4582 on 2024-05-30
and PSF files with insertion codes can now be read.

<!-- readthedocs-preview mdanalysisuserguide start -->
----
📚 Documentation preview 📚: https://mdanalysisuserguide--420.org.readthedocs.build/en/420/

<!-- readthedocs-preview mdanalysisuserguide end -->